### PR TITLE
토큰 검증 시 Id가 반환 되지 않은 문제를 해결하라

### DIFF
--- a/server/src/jwt/jwt.provider.test.ts
+++ b/server/src/jwt/jwt.provider.test.ts
@@ -6,11 +6,9 @@ import { BadRequestException, UnauthorizedException } from '@nestjs/common'
 describe('JwtProvider class', () => {
   let jwtProvider: JwtProvider
 
-  let ACCESS_TOKEN =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXlsb2FkIjp7Im1lbWJlcklkIjoxLCJlbWFpbCI6ImFiY0BlbWFpbC5jb20iLCJtZW1iZXJOYW1lIjoi7ZmN6ri464-ZIiwibWVtYmVyVHlwZSI6IkdFTkVSQUwiLCJwYXNzd29yZCI6IjEyMzQ1Njc4IiwicmVmcmVzaFRva2VuIjoiZXlKaGJHY2lPaUpJIiwidG9rZW5FeHBpcmF0aW9uVGltZSI6IjIwMjMtMDktMDFUMjM6MTA6MDAuMDA5WiIsInJvbGUiOiJVU0VSIiwiY3JlYXRlVGltZSI6IjIwMjMtMDktMDFUMjM6MTA6MDAuMDA5WiIsInVwZGF0ZVRpbWUiOiIyMDIzLTA5LTAxVDIzOjEwOjAwLjAwOVoiLCJjcmVhdGVCeSI6Iu2Zjeq4uOuPmSIsIm1vZGlmaWVkQnkiOiLquYDssqDsiJgifSwiaWF0IjoxNjk0MzEzOTIyLCJleHAiOjE2OTQ0MDAzMjJ9.F5gN5mkLFk6nET2pJ78_sTdb_YIStT7u8ei7rfK1I7c'
-
   let INVALID_ACCESS_TOKEN =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXlsb2FkIjp7Im1lbWJlcklkIjoxLCJlbWFpbCI6ImFiY0BlbWFpbC5jb20iLCJtZW1iZXJOYW1lIjoi7ZmN6ri464-ZIiwibWVtYmVyVHlwZSI6IkdFTkVSQUwiLCJwYXNzd29yZCI6IjEyMzQ1Njc4IiwicmVmcmVzaFRva2VuIjoiZXlKaGJHY2lPaUpJIiwidG9rZW5FeHBpcmF0aW9uVGltZSI6IjIwMjMtMDktMDFUMjM6MTA6MDAuMDA5WiIsInJvbGUiOiJVU0VSIiwiY3JlYXRlVGltZSI6IjIwMjMtMDktMDFUMjM6MTA6MDAuMDA5WiIsInVwZGF0ZVRpbWUiOiIyMDIzLTA5LTAxVDIzOjEwOjAwLjAwOVoiLCJjcmVhdGVCeSI6Iu2Zjeq4uOuPmSIsIm1vZGlmaWVkQnkiOiLquYDssqDsiJgifSwiaWF0IjoxNjk0MzEzOTIyLCJleHAiOjE2OTQ0MDAzMjJ9.F5gN5mkLFk6nET2pJ78_sTdb_YIStT7u8ei7rfK1I123'
+  const Id = 1
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,7 +20,6 @@ describe('JwtProvider class', () => {
 
   describe('generateAccessToken method', () => {
     context('사용자 정보가 주어 질 때', () => {
-      const Id = 1
       it('accessToken을 리턴 해야 한다', () => {
         const accessToken = jwtProvider.generateAccessToken(Id)
 
@@ -34,13 +31,13 @@ describe('JwtProvider class', () => {
 
     context('accessToken이 검증을 성공하면', () => {
       it('id를 리턴 해야 한다.', () => {
-        const decoded = jwtProvider.validateToken(ACCESS_TOKEN)
+        const payload = jwtProvider.validateToken(jwtProvider.generateAccessToken(Id))
 
-        expect(decoded).toEqual(1)
+        expect(payload).toEqual(1)
       })
     })
     context('accessToken이 검증을 실패하면', () => {
-      it('JsonWebTokenError을 던져야 한다', () => {
+      it('UnauthorizedException을 던져야 한다', () => {
         try {
           jwtProvider.validateToken(INVALID_ACCESS_TOKEN)
         } catch (e) {

--- a/server/src/jwt/jwt.provider.ts
+++ b/server/src/jwt/jwt.provider.ts
@@ -20,7 +20,7 @@ export class JwtProvider {
     try {
       const { payload } = jwt.verify(token, process.env.JWT_SECRET) as jwt.JwtPayload
 
-      return payload.memberId
+      return payload
     } catch (e) {
       throw new UnauthorizedException('인증 할 수 없는 token 입니다')
     }


### PR DESCRIPTION
## 문제
생성 된 토큰을 검증하는 validateToken 메서드에서 id가 리턴 되지 않은 문제가 생겼습니다. 토큰이 생성이 되고 해당 토큰을 검증을 하면 id가 반환이 되어야 하는데 `UnauthorizedException`에러가 출력이 됩니다.

## 예시
1. 전체 테스트 코드를 실행합니다.
![토큰 에러](https://github.com/jihwooon/shppingMall/assets/68071599/1b13a83b-65e5-4163-bcee-a19638151e5c)

2. 디버거 모드에서 확인합니다.
![토큰 실패 확인](https://github.com/jihwooon/shppingMall/assets/68071599/adf75023-0c3f-4055-881f-871c96cf0057)

3. 에러가 발생한 지점을 확인합니다.
![토큰 만료 에러](https://github.com/jihwooon/shppingMall/assets/68071599/ec5755a4-be26-4940-b034-e681cd3c4c25)


## 답변
디버거 모드에서 확인 했을 때 생성 된 토큰의 만료 시간이 지나서 에러가 발생한 원인입니다.
![토큰 만료 시간](https://github.com/jihwooon/shppingMall/assets/68071599/e753b6b8-1392-4fcd-9899-a2f65b170404)

새로운 토큰을 발급해서 바꾸면 다음과 같은 결과가 나타납니다.
![토큰 변경 결과](https://github.com/jihwooon/shppingMall/assets/68071599/83d90462-9465-4a36-9662-2d85e3e2e502)

이전 결과와 다르게 이번에는 결과 값이 `undefind`가 출력이 됩니다.

토큰 만료에서 새로운 문제가 발생해서 문제를 다음과 같이 해결을 진행했습니다.

만료 시간마다 새로운 토큰으로 변경하는 하는 일은 자동화 테스트에 올바른 선택은 아닙니다. 그래서 테스트 할 때마다 새로운 토큰이 발급 할 수 있게 로직을 수정했습니다.

```typescript
context('accessToken이 검증을 성공하면', () => {
    it('id를 리턴 해야 한다.', () => {
        const decoded = jwtProvider.validateToken(jwtProvider.generateAccessToken(Id))

        expect(decoded).toEqual(1)
    })
})

```

`jwtProvider.generateAccessToken(Id)` ID값이 주어지면 토큰을 발급 할 수 있게 생성하는 함수 입니다. 함수를 직접 넣어 테스트 실행 할 때마다 토큰을 발급 할 수 있게 수정했습니다.

이때도 아직 `undefined`가 출력이 됩니다.

디버깅으로 로직을 확인 합니다.
![payload](https://github.com/jihwooon/shppingMall/assets/68071599/41ce71b6-e61c-489e-9357-c2a54d3e585f)

출력하는 값이 잘 못 되었다는 걸을 확인 했습니다.

`payload` 값은 1이지만 `paylaod.memberId`는 존재 하지 않는 값으로 `undefined` 발생 했었습니다.

반환 값을 `payload`로 변경을 하고 나서 테스트를 실행 했습니다.

![테스트 통과](https://github.com/jihwooon/shppingMall/assets/68071599/ba3b8995-1a3e-4463-928c-dfad6d8c1f88)

테스트를 통과했습니다.

## 결과
이전에 테스트 코드를 실행 했을 때는 문제가 발생하지 않았지만 최근에 테스트코드를 실행하면서 에러가 발생했습니다. 토큰 만료시간이 지나고 나서야 문제가 발생하는 것을 알게되었습니다. 만약 테스트 코드가 작성 되어 있지 않았다면 문제를 빠르게 찾을 수 없었을 것이었습니다.




