### PR TITLE
이메일 중복 체크하는 repository 쿼리를 수정하라

### DIFF
--- a/server/src/members/domain/member.repository.test.ts
+++ b/server/src/members/domain/member.repository.test.ts
@@ -94,7 +94,7 @@ describe('MemberRepository class', () => {
   describe('existsByEmail method', () => {
     context('가입 된 email이 존재하면', () => {
       beforeEach(async () => {
-        connection.execute = jest.fn().mockResolvedValue([[{ email: 1 }] as RowDataPacket[], []])
+        connection.execute = jest.fn().mockResolvedValue([[{ emailCount: 1 }] as RowDataPacket[], []])
       })
       it('true를 리턴해야 한다', async () => {
         const exitedEmail = await memberRepository.existsByEmail(REGISTERED_EMAIL)
@@ -105,7 +105,7 @@ describe('MemberRepository class', () => {
 
     context('가입 된 email이 존재하지 않으면', () => {
       beforeEach(async () => {
-        connection.execute = jest.fn().mockResolvedValue([[{ email: 0 }] as RowDataPacket[], []])
+        connection.execute = jest.fn().mockResolvedValue([[{ emailCount: 0 }] as RowDataPacket[], []])
       })
       it('false를 리턴해야 한다', async () => {
         const exitedEmail = await memberRepository.existsByEmail(UNSUBSCRIBED_EMAIL)

--- a/server/src/members/domain/member.repository.ts
+++ b/server/src/members/domain/member.repository.ts
@@ -62,13 +62,14 @@ export class MemberRepository {
   }
 
   async existsByEmail(email: string): Promise<boolean> {
-    const [rows] = await this.connection.execute<RowDataPacket[]>('SELECT COUNT(email) FROM member WHERE email = ?', [
-      email,
-    ])
+    const [rows] = await this.connection.execute<RowDataPacket[]>(
+      'SELECT COUNT(email) as emailCount FROM member WHERE email = ?',
+      [email],
+    )
 
     const row = rows ?? []
 
-    if (row[0].email >= 1) {
+    if (row[0].emailCount >= 1) {
       return true
     }
 


### PR DESCRIPTION
## 문제
동일한 이메일로 회원 가입 요청 시 회원 가입이 진행 되는 경우가 생겼습니다. 원래는 동일한 이메일로 가입 요청 시 emailChecker에서 
이메일 중복을 체크하고 에러가 발생을 해야 하는데 이 기능이 작동하지 않는 문제가 발생했습니다.

## 예시
1. 회원 가입 요청을 합니다.
![회원 가입 요청](https://github.com/jihwooon/shpping-mall/assets/68071599/dd75f5fb-c1c3-428b-bade-557e81bfb923)

2. 회원 가입 요청 성공합니다
![회원가입 성공](https://github.com/jihwooon/shpping-mall/assets/68071599/26043219-23ff-4292-b468-4b0fca3b0247)


3. 동일한 이메일로 다시 회원 가입을 요청합니다.
![재요청 회원가입](https://github.com/jihwooon/shpping-mall/assets/68071599/ef3c1156-8d53-41f2-aeef-2f0845ad19ae)


4. 만약 동일한 이메일이 요청을 들어오면 "동일한 이메일이 이미 존재합니다" 에러가 발생해야 하는데 회원가입이 성공합니다.
![재가입 요청 성공](https://github.com/jihwooon/shpping-mall/assets/68071599/d39119e7-8473-4360-b4b5-36fcab0c256c)



## 답변
`COUNT(email)`은 `{'COUNT(email): 갯수'}` object로 반환합니다. 그렇기에 `COUNT(email)`를 `row[0].COUNT(email)`로 변수로 불러와야 갯수를 불러 올 수 있습니다. 그맇지만 **sql alias(`별명`)**로 emailCount로 바꿔 변수를 불러 올 수 있게 수정을 했습니다

```typescript
const [rows] = await this.connection.execute<RowDataPacket[]>(
  'SELECT COUNT(email) as emailCount FROM member WHERE email = ?',
  [email],
)

if (row[0].emailCount >= 1) {
  return true
}
```
count 갯수가 정상적으로 출력이 됩니다
![갯수 출력](https://github.com/jihwooon/shpping-mall/assets/68071599/fde75361-1400-4ea1-8284-bde275e6dbd0)

동일한 이메일로 가입 시 에러가 발생하고 기능도 정상적으로 작동합니다.
![재가입 시 요청 실패](https://github.com/jihwooon/shpping-mall/assets/68071599/30745a6b-d3c6-4854-b5f1-c796f4bd53b8)


## 결과
node sql count 쿼리에서 갯수를 가져올 때 object로 반환해서 컬럼 명칭을 변수로 가져오는 것을 알게되었습니다.


## 참고 사항
- [MySQL COUNT the number of records](https://stackoverflow.com/questions/11412599/node-js-mysql-count-the-number-of-records)