### PR TITLE
GitAction 빌드 시 변경 사항만 테스트를 실행하라

### DIFF
--- a/.github/workflows/server-deploy.yml
+++ b/.github/workflows/server-deploy.yml
@@ -49,8 +49,8 @@ jobs:
         if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         run: npm ci
 
-      - name: Run Test
-        run: npm test
+      - name: Run Test(only Changed)
+        run: npm run test:only-changed
 
       - name: Run Build
         run: npm run build

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./jest.config.cjs"
+    "test:e2e": "jest --config ./jest.config.cjs",
+    "test:only-changed": "jest --onlyChanged"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",


### PR DESCRIPTION
## 요약 (Summary)
GitAction Build 시 변경 된 사항에만 테스트를 진행합니다.

## 배경 (Background)
GitAction이 테스트를 실행 시 전체 테스트를 실행합니다. 이 때 전체 테스트는 CI/CD build 시간이 상당 부분을 소유합니다. 이미 검증된 테스트에서 또 다시 실행하는 것은 비효율이기 때문에 변경 된 사항만 테스트를 진행함으로써 build 시간을 단축 시킬 것 입니다

## 계획 (Plan)
1. `Jest` 공식 문서에 변경 된 사항만 테스트를 실행하는 명령 플래그가 있습니다.
2. npm scripts에 명령 플래그를 추가합니다.
3. GitAction에 npm에 추가한 test 명령어를 추가합니다
4. Pull Request 시 GitAction Script 명령어를 실행합니다

## 참고 사항
[Jest --onlyChanged](https://jestjs.io/docs/cli#--changedsince)