### PR TITLE
입력 받은 패스워드와 저장 된 패스워드를 비교하는 메서드를 리팩터링을 하라

### DIFF
--- a/server/src/auth/signin/application/signin.service.ts
+++ b/server/src/auth/signin/application/signin.service.ts
@@ -15,13 +15,13 @@ export class SigninService {
     private readonly tokenIssuer: TokenIssuer,
   ) {}
 
-  async login(email: string, password: string): Promise<Authentication> {
+  async login(email: string, rawPassword: string): Promise<Authentication> {
     const member = await this.memberRepository.findByEmail(email)
     if (!member) {
       throw new MemberNotFoundException('회원 정보를 찾을 수 없습니다')
     }
 
-    const isPasswordMatch = await this.passwordProvider.comparePassword(password, member)
+    const isPasswordMatch = await this.passwordProvider.comparePassword(rawPassword, member.password)
     if (!isPasswordMatch) {
       throw new BadRequestException('패스워드가 일치 하지 않습니다')
     }

--- a/server/src/members/application/password.provider.test.ts
+++ b/server/src/members/application/password.provider.test.ts
@@ -52,14 +52,14 @@ describe('PasswordProvider class', () => {
   describe('comparePassword method', () => {
     context('입력 받은 패스워드와 저장된 패스워드가 일치하면', () => {
       it('true를 리턴 해야 한다', async () => {
-        const hashedPassword = await passwordProvider.comparePassword(RAW_PASSWORD, userMock())
+        const hashedPassword = await passwordProvider.comparePassword(RAW_PASSWORD, userMock().password)
 
         expect(hashedPassword).toEqual(true)
       })
     })
     context('입력 받은 패스워드와 저장된 패스워드가 일치하지 않으면', () => {
       it('false를 리턴 해야 한다', async () => {
-        const hashedPassword = await passwordProvider.comparePassword(FAIL_PASSWORD, userMock())
+        const hashedPassword = await passwordProvider.comparePassword(FAIL_PASSWORD, userMock().password)
 
         expect(hashedPassword).toEqual(false)
       })

--- a/server/src/members/application/password.provider.ts
+++ b/server/src/members/application/password.provider.ts
@@ -1,7 +1,5 @@
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
 import * as bcrypt from 'bcrypt'
-import { BadRequestException } from '@nestjs/common'
-import { Member } from '../domain/member.entity'
 
 @Injectable()
 export class PasswordProvider {
@@ -15,7 +13,7 @@ export class PasswordProvider {
     return hashedPassword
   }
 
-  async comparePassword(password: string, member: Member): Promise<boolean> {
-    return bcrypt.compare(password, member.password)
+  async comparePassword(rawPassword: string, password: string): Promise<boolean> {
+    return bcrypt.compare(rawPassword, password)
   }
 }


### PR DESCRIPTION
password 변수명은 추상적으로 표현되어 있어서 rawPassword즉 암호화 되지 않은 패스워드로 사용하는게 좀 더 명확하다고 판단이 되어 수정했습니다 comparedPassword 메서드의 파라미터에서 Member는 어떤 값을 비교하는지 의도를 알아내기가 어려워서 Member.password가 더 분명함으로 수정했습니다