### PR TITLE
상품 Id가 주어지고 이미지 파일을 찾을 수 없을 때 예외 처리를 하라

### DIFF
--- a/server/src/item-images/application/item-image.updater.ts
+++ b/server/src/item-images/application/item-image.updater.ts
@@ -3,13 +3,20 @@ import { ItemImageRepository } from '../domain/item-image.repository'
 import { Item } from '../../items/domain/item.entity'
 import { ItemImage } from '../domain/item-image.entity'
 import { existsSync, unlink } from 'fs'
+import { ItemImageNotFoundException } from '../error/ItemImage-not-found.exception'
 
 @Injectable()
 export class ItemImageUpdater {
   constructor(private readonly itemImageRepository: ItemImageRepository) {}
 
   async updateItemImages(files: Express.Multer.File[], items: Item) {
-    const itemImages = await this.itemImageRepository.findByItemOrderByItemImageIdAsc(items.id)
+    const { id } = items
+
+    const itemImages = await this.itemImageRepository.findByItemOrderByItemImageIdAsc(id)
+    if (Array.isArray(itemImages) && itemImages.length === 0) {
+      throw new ItemImageNotFoundException(`${id}에 해당하는 이미지를 찾을 수 없습니다.`)
+    }
+
     files.map((file, i) => {
       this.updateItemImage(itemImages[i], { ...file })
     })

--- a/server/src/item-images/error/ItemImage-not-found.exception.ts
+++ b/server/src/item-images/error/ItemImage-not-found.exception.ts
@@ -1,0 +1,10 @@
+import { NotFoundException } from '@nestjs/common'
+
+export class ItemImageNotFoundException extends NotFoundException {
+  constructor(message: string) {
+    super(message, {
+      cause: 'itemImage',
+      description: 'ITEMIMAGE_NOT_FOUND',
+    })
+  }
+}


### PR DESCRIPTION
## 문제
상품 ID는 존재하지만 상품 이미지 파일이 존재하지 않을 때 에러가 발생했습니다. 상품 이미지 테이블에서 상품 id가 존재 하지 않을 시 
**findByItemOrderByItemImageIdAsc** 쿼리에서 **빈배열**(`[]`) 을 반환하도록 작성되어 있지만 빈배열을 ID값으로 전환 할 수 없어서 에러가 발생합니다.

## 예시
1. `localhost:8080/admin/items/1` API 요청을 합니다.
![상품Id](https://github.com/jihwooon/shpping-mall/assets/68071599/dd426da7-6c7c-4bdd-8075-bddba42aa194)
2.  상품 Id가 주어지고 ImageItem 테이블에 상품 ID가 존재 않습니다
![상품Id](https://github.com/jihwooon/shpping-mall/assets/68071599/50270324-0f8d-49cd-9e41-bb530ee2f02b)
3. 다음과 같은 에러가 발생합니다.
![error](https://github.com/jihwooon/shpping-mall/assets/68071599/d163f49e-2271-4cc1-84a5-a1a79a9882d4)

## 답변
결과값은 빈 배열이 넘어오고 ID를 반환하지 않은 문제가 생기는 문제입니다. 

```javascript
async updateItemImages(files: Express.Multer.File[], items: Item) {
  const { id } = items

  const itemImages = await this.itemImageRepository.findByItemOrderByItemImageIdAsc(id)
  if (Array.isArray(itemImages) && itemImages.length === 0) {
    throw new ItemImageNotFoundException(`${id}에 해당하는 이미지를 찾을 수 없습니다.`)
  }

  files.map((file, i) => {
    this.updateItemImage(itemImages[i], { ...file })
  })
}
```
빈 배열이 넘어 올 시 배열인지 아닌지 검증하는 구문과 배열의 길이가 0인 것을 확인을 하고 예외 처리를 했습니다

## 참고 사항
- [.length로 JavaScript 배열이 비어 있는지 확인하는 방법](https://www.freecodecamp.org/korean/news/check-if-javascript-array-is-empty-or-not-with-length/)